### PR TITLE
feat: add support to assign an endpoint for AWS S3

### DIFF
--- a/src/aws.ts
+++ b/src/aws.ts
@@ -57,11 +57,15 @@ export default class AWSClient implements IAWOS {
         options.region,
         'options.region is required when options.s3ForcePathStyle = false'
       );
-      this.client = new AWS.S3({
+      const s3Options: any = {
         accessKeyId: options.accessKeyId,
         secretAccessKey: options.secretAccessKey,
         region: options.region,
-      });
+      };
+      if (options.endpoint) {
+        s3Options.endpoint = options.endpoint;
+      }
+      this.client = new AWS.S3(s3Options);
     }
 
     this.bucket = options.bucket;


### PR DESCRIPTION
配合 [AWS VPC Endpoint](https://github.com/aws/aws-sdk-go-v2/blob/b7d8e15425d2f86a0596e8d7db2e33bf382a21dd/example/service/s3/usingPrivateLink/README.md) 使用的时候需要指定 endpoint 字段。